### PR TITLE
Implement dynamic LeetCode detail retrieval

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -120,3 +120,28 @@ def test_random_problem_not_found(monkeypatch):
     monkeypatch.setattr(app, "fetch_problems", lambda: app.LOCAL_PROBLEMS)
     response = client.get("/random?difficulty=Impossible")
     assert response.status_code == 404
+
+
+def test_random_problem_fetch_detail(monkeypatch):
+    problems = [
+        {
+            "id": 1234,
+            "title": "Burst Balloons",
+            "difficulty": "Hard",
+            "url": "https://leetcode.com/problems/burst-balloons/",
+            "content": "",
+            "sampleTestCase": "",
+        }
+    ]
+
+    monkeypatch.setattr(app, "fetch_problems", lambda: problems)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+
+    def fake_detail(slug):
+        assert slug == "burst-balloons"
+        return {"content": "Some description", "sampleTestCase": "case"}
+
+    monkeypatch.setattr(app, "fetch_problem_detail", fake_detail)
+    response = client.get("/random?difficulty=Hard", headers={"accept": "text/html"})
+    assert response.status_code == 200
+    assert "Some description" in response.text


### PR DESCRIPTION
## Summary
- add helper `fetch_problem_detail` for LeetCode GraphQL queries
- enrich problems in `/random` with details when missing
- test retrieval of problem details for problems not in `problems.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464acac018832a850a7f8475e5020e