### PR TITLE
Add simple code runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ This repository provides a small web application to help you practice LeetCode p
    ```
 3. Open `http://localhost:8000` in your browser and choose a difficulty.
 
+## Online Code Runner
+
+Once you select a problem you can navigate to `/solve/<slug>` (e.g. `/solve/two-sum`)
+to open a simple editor. Write Python code and press **Run Code** to execute it
+server‑side. The `/execute` API endpoint runs the submitted code using the local
+Python interpreter and returns the output.
+
 ## Docker
 
 You can also run the application using Docker Compose:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -145,3 +145,16 @@ def test_random_problem_fetch_detail(monkeypatch):
     response = client.get("/random?difficulty=Hard", headers={"accept": "text/html"})
     assert response.status_code == 200
     assert "Some description" in response.text
+
+
+def test_solve_page(monkeypatch):
+    monkeypatch.setattr(app, "fetch_problems", lambda: app.LOCAL_PROBLEMS)
+    response = client.get("/solve/two-sum")
+    assert response.status_code == 200
+    assert "textarea" in response.text
+
+
+def test_execute_code():
+    response = client.post("/execute", json={"code": "print('hi')"})
+    assert response.status_code == 200
+    assert response.json()["stdout"].strip() == "hi"


### PR DESCRIPTION
## Summary
- add a `solve` page with a code editor
- implement `/execute` API to run submitted code
- document the new feature in README
- test the new endpoints

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684652d7e030832aa5aafbeda3b67cb0