### PR TITLE
Add multi-language code runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This repository provides a small web application to help you practice LeetCode p
 
 ## Online Code Runner
 
-Once you select a problem you can navigate to `/solve/<slug>` (e.g. `/solve/two-sum`)
-to open a simple editor. Write Python code and press **Run Code** to execute it
-server‑side. The `/execute` API endpoint runs the submitted code using the local
-Python interpreter and returns the output.
+Once you select a problem you can run code directly on the problem page. Select
+the desired language (Python, C++, Java or Go), write your solution and press
+**Run Code**. The `/execute` endpoint will compile/execute the submitted code
+with the corresponding local interpreter and return the output.
 
 ## Docker
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -154,7 +154,28 @@ def test_solve_page(monkeypatch):
     assert "textarea" in response.text
 
 
-def test_execute_code():
-    response = client.post("/execute", json={"code": "print('hi')"})
+def test_execute_code_python():
+    response = client.post("/execute", json={"code": "print('hi')", "language": "python"})
     assert response.status_code == 200
     assert response.json()["stdout"].strip() == "hi"
+
+
+def test_execute_code_cpp():
+    code = "#include <iostream>\nint main(){std::cout<<\"hi\";return 0;}"
+    resp = client.post("/execute", json={"code": code, "language": "cpp"})
+    assert resp.status_code == 200
+    assert resp.json()["stdout"].strip() == "hi"
+
+
+def test_execute_code_java():
+    code = "public class Main { public static void main(String[] args){ System.out.println(\"hi\"); } }"
+    resp = client.post("/execute", json={"code": code, "language": "java"})
+    assert resp.status_code == 200
+    assert resp.json()["stdout"].strip() == "hi"
+
+
+def test_execute_code_go():
+    code = "package main\nimport \"fmt\"\nfunc main(){fmt.Print(\"hi\")}"
+    resp = client.post("/execute", json={"code": code, "language": "go"})
+    assert resp.status_code == 200
+    assert resp.json()["stdout"].strip() == "hi"


### PR DESCRIPTION
## Summary
- integrate code runner with the generated problem page
- add language selector and update JavaScript
- extend `/execute` endpoint to run Python, C++, Java and Go
- update README docs
- test new language runners

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846554c890c832a9d11ca51081d7df0