### PR TITLE
Fix missing compilers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.11-slim
 
+# Install compilers for the online code runner
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        g++ \
+        openjdk-17-jdk-headless \
+        golang-go && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install uv - a fast Python package manager
 RUN pip install --no-cache-dir uv
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ This repository provides a small web application to help you practice LeetCode p
    ```
 3. Open `http://localhost:8000` in your browser and choose a difficulty.
 
+For languages other than Python you also need local compilers available. On
+Debian/Ubuntu you can install them with:
+```bash
+sudo apt install g++ openjdk-17-jdk-headless golang-go
+```
+If you run the app via Docker these are installed automatically.
+
 ## Online Code Runner
 
 Once you select a problem you can run code directly on the problem page. Select


### PR DESCRIPTION
## Summary
- install g++, OpenJDK and Go in the Docker image
- document local compiler requirement in README

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6846572dd740832abcd7be54b0cd5934