### PR TITLE
Modify difficulty selector label in index page

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,10 +33,10 @@ INDEX_HTML = """
   <body class="bg-light">
     <div class="container py-5">
       <h1 class="mb-2 text-center">Code Trainer</h1>
-      <h2 class="mb-4 text-center">Select Difficulty</h2>
       <form class="row g-3 justify-content-center" action="/random" method="get">
         <div class="col-auto">
-          <select class="form-select" name="difficulty">
+          <label for="difficulty-select" class="form-label me-2">Select Difficulty</label>
+          <select id="difficulty-select" class="form-select" name="difficulty">
             <option value="Easy">Easy</option>
             <option value="Medium">Medium</option>
             <option value="Hard">Hard</option>


### PR DESCRIPTION
## Summary
- remove the `Select Difficulty` header on the index page
- add a label element for the difficulty dropdown

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684671661d24832aa4b4d1bc8aaa6826