### PR TITLE
Add sample test verification

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -179,3 +179,12 @@ def test_execute_code_go():
     resp = client.post("/execute", json={"code": code, "language": "go"})
     assert resp.status_code == 200
     assert resp.json()["stdout"].strip() == "hi"
+
+
+def test_execute_with_sample_case():
+    code = "print(int(input()) * 2)"
+    sample = "Input: 2\nOutput: 4"
+    resp = client.post("/execute", json={"code": code, "language": "python", "sampleCase": sample})
+    data = resp.json()
+    assert data["stdout"].strip() == "4"
+    assert data["passed"] is True


### PR DESCRIPTION
## Summary
- verify code execution against problem sample cases
- expose sample case in forms and send to /execute
- extend code runner utilities to accept stdin
- parse sample test cases and set `passed` flag
- add test for sample verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684672a9d3e0832a997100bbf8445686