### PR TITLE
Return code templates from LeetCode detail API

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,6 +170,11 @@ def fetch_problem_detail(slug: str) -> dict:
         "  question(titleSlug: $titleSlug) {\n"
         "    content\n"
         "    sampleTestCase\n"
+        "    codeSnippets {\n"
+        "      lang\n"
+        "      langSlug\n"
+        "      code\n"
+        "    }\n"
         "  }\n"
         "}"
     )
@@ -183,9 +188,10 @@ def fetch_problem_detail(slug: str) -> dict:
         return {
             "content": q.get("content", ""),
             "sampleTestCase": q.get("sampleTestCase", ""),
+            "codeSnippets": q.get("codeSnippets", []),
         }
     except Exception:
-        return {"content": "", "sampleTestCase": ""}
+        return {"content": "", "sampleTestCase": "", "codeSnippets": []}
 
 
 def fetch_problems() -> list[dict]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -188,3 +188,29 @@ def test_execute_with_sample_case():
     data = resp.json()
     assert data["stdout"].strip() == "4"
     assert data["passed"] is True
+
+
+def test_fetch_problem_detail_snippets(monkeypatch):
+    sample = {
+        "data": {
+            "question": {
+                "content": "desc",
+                "sampleTestCase": "case",
+                "codeSnippets": [
+                    {"lang": "Python3", "langSlug": "python", "code": "class Solution:"}
+                ],
+            }
+        }
+    }
+
+    class FakeResp:
+        def json(self):
+            return sample
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: FakeResp())
+    detail = app.fetch_problem_detail("two-sum")
+    assert detail["codeSnippets"]
+    assert detail["codeSnippets"][0]["langSlug"] == "python"


### PR DESCRIPTION
## Summary
- query `codeSnippets` in `fetch_problem_detail`
- return the snippets so that templates are available to the UI
- test that snippets are included when requesting problem details

## Testing
- `pip install --quiet -r requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467979dbc0832aa7fe6dc643a2a6b1