### PR TITLE
Add code snippet support

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -149,9 +149,28 @@ def test_random_problem_fetch_detail(monkeypatch):
 
 def test_solve_page(monkeypatch):
     monkeypatch.setattr(app, "fetch_problems", lambda: app.LOCAL_PROBLEMS)
+    monkeypatch.setattr(app, "fetch_problem_detail", lambda slug: {"codeSnippets": [{"lang": "Python3", "langSlug": "python", "code": "print('hi')"}]})
     response = client.get("/solve/two-sum")
     assert response.status_code == 200
     assert "textarea" in response.text
+
+
+def test_solve_page_contains_snippet(monkeypatch):
+    monkeypatch.setattr(app, "fetch_problems", lambda: app.LOCAL_PROBLEMS)
+
+    def fake_detail(slug):
+        return {
+            "content": "desc",
+            "sampleTestCase": "",
+            "codeSnippets": [
+                {"lang": "Python3", "langSlug": "python", "code": "print('hi')"}
+            ],
+        }
+
+    monkeypatch.setattr(app, "fetch_problem_detail", fake_detail)
+    response = client.get("/solve/two-sum")
+    assert response.status_code == 200
+    assert "print('hi')" in response.text
 
 
 def test_execute_code_python():


### PR DESCRIPTION
## Summary
- auto-fetch LeetCode snippets when missing
- expose snippets to HTML templates and add "Start Code" button
- populate textarea with the snippet for the chosen language via JS
- test snippet rendering on the solve page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467bc6f5c4832a84037ccc7a7734b3