### PR TITLE
Ensure default code snippets always available

### DIFF
--- a/app.py
+++ b/app.py
@@ -307,7 +307,18 @@ async def index(request: Request, difficulty: Optional[str] = None):
                     detail = await fetch_problem_detail_async(slug)
                     if detail.get("content") or detail.get("codeSnippets"):
                         problem.update(detail)
-    snippets_json = json.dumps(problem.get("codeSnippets", [])) if problem else "[]"
+    if problem:
+        snippets = problem.get("codeSnippets", [])
+        if not snippets:
+            snippets = [
+                {"lang": "Python3", "langSlug": "python", "code": generate_template(problem, "python")},
+                {"lang": "C++", "langSlug": "cpp", "code": generate_template(problem, "cpp")},
+                {"lang": "Java", "langSlug": "java", "code": generate_template(problem, "java")},
+                {"lang": "Go", "langSlug": "go", "code": generate_template(problem, "go")},
+            ]
+        snippets_json = json.dumps(snippets)
+    else:
+        snippets_json = "[]"
     return HTMLResponse(TEMPLATE.render(problem=problem, snippets_json=snippets_json))
 
 
@@ -333,7 +344,15 @@ async def solve_page(slug: str):
     problem = await get_problem_by_slug(slug)
     if not problem:
         raise HTTPException(status_code=404, detail="Problem not found")
-    snippets_json = json.dumps(problem.get("codeSnippets", []))
+    snippets = problem.get("codeSnippets", [])
+    if not snippets:
+        snippets = [
+            {"lang": "Python3", "langSlug": "python", "code": generate_template(problem, "python")},
+            {"lang": "C++", "langSlug": "cpp", "code": generate_template(problem, "cpp")},
+            {"lang": "Java", "langSlug": "java", "code": generate_template(problem, "java")},
+            {"lang": "Go", "langSlug": "go", "code": generate_template(problem, "go")},
+        ]
+    snippets_json = json.dumps(snippets)
     return HTMLResponse(SOLVE_TEMPLATE.render(problem=problem, snippets_json=snippets_json))
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -194,6 +194,21 @@ def test_solve_page_contains_snippet(monkeypatch):
     assert "print('hi')" in response.text
 
 
+def test_solve_page_default_snippets(monkeypatch):
+    import copy, json
+    with open("problems.json") as f:
+        original = json.load(f)
+    monkeypatch.setattr(app, "fetch_problems", _async_return(copy.deepcopy(original)))
+
+    async def fake_detail(slug):
+        return {"content": "desc", "sampleTestCase": "", "codeSnippets": []}
+
+    monkeypatch.setattr(app, "fetch_problem_detail", fake_detail)
+    response = client.get("/solve/two-sum")
+    assert response.status_code == 200
+    assert "Write your solution" in response.text
+
+
 def test_execute_code_python():
     response = client.post("/execute", json={"code": "print('hi')", "language": "python"})
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- provide fallback snippets in `index` and `solve_page`
- test default snippet rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846898c6918832ab752f5b5e5930fec