### PR TITLE
Default page to C++ templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,8 +63,8 @@ INDEX_HTML = """
           {% endif %}
           <form id="code-form" class="mt-3">
             <select class="form-select mb-2" name="language">
-              <option value="python">Python</option>
               <option value="cpp">C++</option>
+              <option value="python">Python</option>
               <option value="java">Java</option>
               <option value="go">Go</option>
             </select>
@@ -78,14 +78,18 @@ INDEX_HTML = """
       <script id="snippets-data" type="application/json">{{ snippets_json }}</script>
       <script>
         const snippets = JSON.parse(document.getElementById('snippets-data').textContent || '[]');
+        const langSelect = document.querySelector('#code-form select[name="language"]');
+        const codeInput = document.querySelector('#code-form textarea[name="code"]');
         function fillSnippet() {
-          const lang = document.querySelector('#code-form select[name="language"]').value;
+          const lang = langSelect.value;
           const s = snippets.find(sn => sn.langSlug === lang);
           if (s) {
-            document.querySelector('#code-form textarea[name="code"]').value = s.code;
+            codeInput.value = s.code;
           }
         }
+        langSelect.addEventListener('change', fillSnippet);
         document.getElementById('fill-snippet-btn').addEventListener('click', fillSnippet);
+        fillSnippet();
         document.getElementById('code-form').addEventListener('submit', async (e) => {
           e.preventDefault();
           const code = e.target.code.value;
@@ -125,8 +129,8 @@ SOLVE_HTML = """
       {% endif %}
       <form id=\"code-form\" class=\"mb-3\">
         <select class=\"form-select mb-2\" name=\"language\">
-          <option value=\"python\">Python</option>
           <option value=\"cpp\">C++</option>
+          <option value=\"python\">Python</option>
           <option value=\"java\">Java</option>
           <option value=\"go\">Go</option>
         </select>
@@ -139,14 +143,18 @@ SOLVE_HTML = """
     <script id=\"snippets-data\" type=\"application/json\">{{ snippets_json }}</script>
     <script>
       const snippets = JSON.parse(document.getElementById('snippets-data').textContent || '[]');
+      const langSelect = document.querySelector('#code-form select[name="language"]');
+      const codeInput = document.querySelector('#code-form textarea[name="code"]');
       function fillSnippet() {
-        const lang = document.querySelector('#code-form select[name="language"]').value;
+        const lang = langSelect.value;
         const s = snippets.find(sn => sn.langSlug === lang);
         if (s) {
-          document.querySelector('#code-form textarea[name="code"]').value = s.code;
+          codeInput.value = s.code;
         }
       }
+      langSelect.addEventListener('change', fillSnippet);
       document.getElementById('fill-snippet-btn').addEventListener('click', fillSnippet);
+      fillSnippet();
       document.getElementById('code-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const code = e.target.code.value;

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -206,7 +206,7 @@ def test_solve_page_default_snippets(monkeypatch):
     monkeypatch.setattr(app, "fetch_problem_detail", fake_detail)
     response = client.get("/solve/two-sum")
     assert response.status_code == 200
-    assert "Write your solution" in response.text
+    assert "using namespace std" in response.text
 
 
 def test_execute_code_python():


### PR DESCRIPTION
## Summary
- default language option is now C++
- automatically fill the selected template when the page loads
- refresh the template whenever the language selector changes
- update tests for C++ default snippet

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468b326b28832a8e185fc176846674