### PR TITLE
Remove duplicate detail fetcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -225,36 +225,6 @@ async def fetch_problem_detail(slug: str) -> dict:
         return {"content": "", "sampleTestCase": "", "codeSnippets": []}
 
 
-async def fetch_problem_detail_async(slug: str) -> dict:
-    """Asynchronously retrieve problem content and code snippets from LeetCode."""
-    query = (
-        "query getQuestion($titleSlug: String!) {\n"
-        "  question(titleSlug: $titleSlug) {\n"
-        "    content\n"
-        "    sampleTestCase\n"
-        "    codeSnippets {\n"
-        "      lang\n"
-        "      langSlug\n"
-        "      code\n"
-        "    }\n"
-        "  }\n"
-        "}"
-    )
-    payload = {"query": query, "variables": {"titleSlug": slug}}
-    headers = {"User-Agent": "Mozilla/5.0"}
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(GRAPHQL_API, json=payload, headers=headers)
-            resp.raise_for_status()
-            data = resp.json()
-            q = data.get("data", {}).get("question", {})
-            return {
-                "content": q.get("content", ""),
-                "sampleTestCase": q.get("sampleTestCase", ""),
-                "codeSnippets": q.get("codeSnippets", []),
-            }
-    except Exception:
-        return {"content": "", "sampleTestCase": "", "codeSnippets": []}
 
 
 async def fetch_problems() -> list[dict]:
@@ -312,7 +282,7 @@ async def index(request: Request, difficulty: Optional[str] = None):
             if not problem.get("content") or not problem.get("codeSnippets"):
                 slug = problem.get("url", "").rstrip("/").split("/")[-1]
                 if slug:
-                    detail = await fetch_problem_detail_async(slug)
+                    detail = await fetch_problem_detail(slug)
                     if detail.get("content") or detail.get("codeSnippets"):
                         problem.update(detail)
     if problem:


### PR DESCRIPTION
## Summary
- remove the unused `fetch_problem_detail_async` helper
- call `fetch_problem_detail` everywhere for fetching problem details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468ebf9694832a8107f4c085ae0d33