### PR TITLE
Pin versions for FastAPI stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ This repository provides a small web application to help you practice LeetCode p
 
 ## Running the app
 
-1. Install `uv` and the project dependencies:
+1. Install `uv` and the project dependencies pinned in `requirements.txt`:
    ```bash
    pip install uv
    uv pip install -r requirements.txt
    ```
+   These pins currently install:
+   `fastapi==0.110.0`, `starlette==0.36.3`,
+   `httpx==0.27.2`, `uvicorn==0.29.0` and `jinja2==3.1.2`.
 2. Start the server using `uvicorn`:
    ```bash
    uvicorn app:app --reload

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-fastapi
-uvicorn
-httpx
-jinja2
+fastapi==0.110.0
+starlette==0.36.3
+httpx==0.27.2
+uvicorn==0.29.0
+jinja2==3.1.2


### PR DESCRIPTION
## Summary
- pin `fastapi`, `starlette`, `httpx`, `uvicorn` and `jinja2` versions
- document installing these exact versions in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468eb5d694832a86d8a1367ebef382